### PR TITLE
Handle invalid certificate numbers being passed to FDIC::BankFind.find_institution

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,25 +42,32 @@ Currently all of our features are namespaced under the `FDIC::BankFind` module
 
 The FDIC API lets you find an Institution if you have its FDIC Certificate Number:
 
-```
+```ruby
 institution = FDIC::BankFind.find_institution(26588)  #=> FDIC::BankFind::Institution
+```
+
+If your certificate number is incorrect, this will raise an exception:
+
+```ruby
+institution = FDIC::BankFind.find_institution(26588)  #=> FDIC::BankFind::Institution
+# raises FDIC::Exceptions::RecordNotFound
 ```
 
 If you don't have the certificate number, you can search for a Bank by name, and get back all matching Banks:
 
-```
+```ruby
 banks = FDIC::BankFind.find_bank('Dedicated Community Bank')  #=> [FDIC::BankFind::Bank, FDIC::BankFind::Bank, ...]
 ```
 
 Once you have a Bank, you can get its Institution, which has much more data available:
 
-```
+```ruby
 institution = banks.first.find_institution!  # Bang, because it's another network request
 ```
 
 The API also exposes information about an Institution's branches, and its history. You can query both of these on the FDIC::BankFind module directly, or on the Institution:
 
-```
+```ruby
 institution.find_branches!  #=> [FDIC::BankFind::Branch, FDIC::BankFind::Branch, ...]
 FDIC::BankFind.find_branches(25688)   #=> [FDIC::BankFind::Branch, FDIC::BankFind::Branch, ...]
 
@@ -70,7 +77,7 @@ FDIC::BankFind.find_history_events('Dedicated Community Bank', 26588)   #=> [FDI
 
 Since a `Bank` knows its certificate number, it can look up its branch and history information, too.
 
-```
+```ruby
 # These work just like they do on Institutions:
 bank.find_branches!
 bank.find_history_events!
@@ -85,4 +92,3 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/Contin
 ## License
 
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
-

--- a/lib/fdic.rb
+++ b/lib/fdic.rb
@@ -1,6 +1,7 @@
 require 'httparty'
 require 'logger'
 require "fdic/version"
+require 'fdic/exceptions'
 require 'fdic/client'
 require 'fdic/record'
 require 'fdic/bank'
@@ -20,8 +21,12 @@ module FDIC
 
     def find_institution(certificate_number)
       resp = Client.new.find_institution(certificate_number)
-      result = resp['d']['results'].first
-      Institution.new(result)
+      results = resp.fetch('d').fetch('results')
+      if results.empty? || results.nil?
+        raise FDIC::Exceptions::RecordNotFound
+      else
+        Institution.new(results.first)
+      end
     end
 
     def find_branches(certificate_number)

--- a/lib/fdic.rb
+++ b/lib/fdic.rb
@@ -23,7 +23,7 @@ module FDIC
       resp = Client.new.find_institution(certificate_number)
       results = resp.fetch('d').fetch('results')
       if results.empty? || results.nil?
-        raise FDIC::Exceptions::RecordNotFound
+        raise FDIC::Exceptions::RecordNotFound, "#{certificate_number} appears to be an invalid certificate number"
       else
         Institution.new(results.first)
       end

--- a/lib/fdic/exceptions.rb
+++ b/lib/fdic/exceptions.rb
@@ -1,0 +1,5 @@
+module FDIC
+  module Exceptions
+    class RecordNotFound < StandardError; end
+  end
+end

--- a/spec/fdic_spec.rb
+++ b/spec/fdic_spec.rb
@@ -4,4 +4,32 @@ describe FDIC do
   it 'has a version number' do
     expect(FDIC::VERSION).not_to be nil
   end
+
+  describe FDIC::BankFind do
+    describe '.find_institution' do
+      context 'when the certificate_number is invalid' do
+        let(:invalid_certificate_number) { 63977 }
+        let(:empty_response) {
+          {
+            'd' => {
+              'results' => [],
+              '__count' => '0',
+              '__next' => "http://odata.fdic.gov:80/financial-institution/Institution?$format=json&$filter=certNumber%20eq%20#{invalid_certificate_number}&$skiptoken=0,0"
+            }
+          }
+        }
+
+        it 'raises a RecordNotFound exception' do
+          allow(FDIC::BankFind::Client).to receive(:find_institution).
+            with( invalid_certificate_number ).
+            and_return( empty_response )
+
+          expect {
+            FDIC::BankFind.find_institution(invalid_certificate_number)
+          }.to raise_error(FDIC::Exceptions::RecordNotFound)
+
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR addresses issue #2 