### PR TITLE
check the response code of the FDIC, if the code is in the 500 range, raise a ServerError.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,19 @@ institution = FDIC::BankFind.find_institution(26588)  #=> FDIC::BankFind::Instit
 # raises FDIC::Exceptions::RecordNotFound
 ```
 
+Note, sometimes seemingly "valid" parameters will cause the FDIC to return a 500 error code.
+```ruby
+institution = FDIC::BankFIND.find_institution("DOG") # Not a number
+institution = FDIC::BankFIND.find_institution(1234567898798) # a number with more than 10 digits
+# the FDIC returns 500
+```
+
+When this happens, the gem will catch the error and raise an exception:
+```ruby
+institution = FDIC::BankFIND.find_institution(1234567898798) # a number with more than 10 digits
+# raises FDIC::Exceptions::ServerError
+```
+
 If you don't have the certificate number, you can search for a Bank by name, and get back all matching Banks:
 
 ```ruby

--- a/lib/fdic/bank_find/exceptions.rb
+++ b/lib/fdic/bank_find/exceptions.rb
@@ -1,5 +1,6 @@
 module FDIC
   module Exceptions
     class RecordNotFound < StandardError; end
+    class ServerError < StandardError; end
   end
 end

--- a/spec/fdic/client_spec.rb
+++ b/spec/fdic/client_spec.rb
@@ -1,11 +1,25 @@
 require 'spec_helper'
 
 describe FDIC::BankFind::Client do
-  it "escapes single-quotes by doubling them up. ' -> ''" do
-    expect(FDIC::BankFind::Client).to receive(:get) do |action, query|
-      expect(query[:query]['$filter']).to include("PEOPLE''S UNITED")
+  describe '#find_bank' do
+    it "escapes single-quotes by doubling them up. ' -> ''" do
+      safe_response = double("HTTParty::Response", code: 200)
+      expect(FDIC::BankFind::Client).to receive(:get) do |action, query|
+        expect(query[:query]['$filter']).to include("PEOPLE''S UNITED")
+      end.and_return(safe_response)
+
+      FDIC::BankFind::Client.new.find_bank("People's United")
     end
 
-    FDIC::BankFind::Client.new.find_bank("People's United")
+    context 'when the FDIC is having struggles' do
+      it 'raises an exception' do
+        response = double("HTTParty::Response", code: 500)
+        allow(FDIC::BankFind::Client).to receive(:get).and_return(response)
+
+        expect {
+          FDIC::BankFind::Client.new.find_bank("foo")
+        }.to raise_error(FDIC::Exceptions::ServerError)
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR provides some error handling for the gem. Specifically, if for whatever reason the FDIC starts returning 500 errors, then we can reraise our own errors, which can be gracefully handled by our users.

#4 and #6 specifically deal with issues related to the FDIC returning errors (the former when the API seems to be non-functional, and the latter as a result of passing query parameters that appear to break some part of their infrastructure.)

@danbernier @jhirbour thoughts?